### PR TITLE
Update "date" record.

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   mllist
 author Adrian Sai-wah Tam
 email  adrian.sw.tam@gmail.com
-date   2007-06-06
+date   2018-11-03
 name   Multiline list plugin
 desc   Allows a list item to break into multiple lines with indentation on non-bullet lines
 url    http://www.dokuwiki.org/plugin:mllist


### PR DESCRIPTION
According to a discussion in the Dokuwiki forum
[https://forum.dokuwiki.org/thread/16412](url)
both the "date" information and the plugin info page should be updated. I've already done the latter, see
[https://www.dokuwiki.org/plugin:mllist](url).