### PR TITLE
Compatible declaration with DokuWiki_Syntax_Plugin

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -53,7 +53,7 @@ class syntax_plugin_mllist extends DokuWiki_Syntax_Plugin {
     $this->Lexer->addExitPattern('\n','plugin_mllist');
   }
 
-  function handle($match, $state, $pos, $handler){
+  function handle($match, $state, $pos, Doku_Handler $handler){
     switch ($state){
       case DOKU_LEXER_ENTER:
         $ReWriter = new Lists($handler->getCallWriter());
@@ -78,7 +78,7 @@ class syntax_plugin_mllist extends DokuWiki_Syntax_Plugin {
     return true;
   }
 
-  function render($mode, $renderer, $data){
+  function render($mode, Doku_Renderer $renderer, $data){
     return true;
   }
 }


### PR DESCRIPTION
Fixed PHP Fatal error

```
Declaration of syntax_plugin_mllist::handle  must be compatible with dokuwiki\Extension\SyntaxPlugin::handle
Declaration of syntax_plugin_mllist::render must be compatible with dokuwiki\Extension\SyntaxPlugin::render
```